### PR TITLE
Improved on the equation solver design in Pyro.Math & Pyro.Nc.Parsing

### DIFF
--- a/Pyro.Math/Solver.cs
+++ b/Pyro.Math/Solver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -7,21 +8,34 @@ namespace Pyro.Math
 {
     public static class Solver
     {
+        public enum Operation
+        {
+            Default,
+            Addition, 
+            Subtraction,
+            Multiplication,
+            Division,
+            Factorization
+        }
         public struct SolverResult
         {
             private static StringBuilder Builder = new StringBuilder();
-            public SolverResult(bool isNumber, double value)
+            public SolverResult(bool isNumber, double value, Operation op = Operation.Default, string id = "")
             {
                 IsNumber = isNumber;
                 Value = value;
+                Op = op;
+                Id = id;
             }
-            
+
             public bool IsNumber { get; set; }
             public double Value { get; set; }
+            public string Id { get; set; }
+            public Operation Op { get; set; }
 
             public static implicit operator SolverResult(double d)
             {
-                return new SolverResult(true, d);
+                return new SolverResult(true, d, default);
             }
 
             public override string ToString()
@@ -31,7 +45,7 @@ namespace Pyro.Math
                     Builder.Clear();
                     if (!IsNumber)
                     {
-                        Builder.Append(System.Math.Abs(Value - 1) > 0.001d ? Value.ToString(CultureInfo.InvariantCulture) : string.Empty).Append('X');
+                        Builder.Append(System.Math.Abs(Value - 1) > 0.001d ? Value.ToString(CultureInfo.InvariantCulture) : string.Empty).Append(Id);
                     }
                     else
                     {
@@ -55,8 +69,37 @@ namespace Pyro.Math
 
             public static implicit operator SolverResultString(List<SolverResult> results)
             {
-                var sb = new StringBuilder(results.FirstOrDefault().ToString()).Append(" = ").Append((results.Count > 1 ? results[1] : default).ToString());
+                //var sb = new StringBuilder(results.FirstOrDefault().ToString()).Append(" = ").Append((results.Count > 1 ? results[1] : default).ToString());
+                var sb = new StringBuilder();
+                List<double> numbers = new();
+                SolverResult last = default;
+                foreach (var result in results)
+                {
+                    if (result.IsNumber)
+                    {
+                        numbers.Add(result.Value);
+                    }
+                    else
+                    {
+                        if (result.Value < 0)
+                        {
+                            sb.Append('-').Append(' ');
+                        }
 
+                        if (last.Id != null)
+                        {
+                            if (result.Value > 0)
+                            {
+                                sb.Append('+').Append(' ');
+                            }
+                        }
+                        sb.Append(result.Value is 1 or -1 ? "" : result.Value.ToString(CultureInfo.InvariantCulture)).Append(result.Id).Append(' ');
+                        last = result;
+                    }
+                }
+
+                sb.Append('=').Append(' ');
+                sb.Append(numbers.Sum());
                 return new SolverResultString(sb.ToString());
             }
         }
@@ -83,7 +126,7 @@ namespace Pyro.Math
             }
             if (!equation.Contains("="))
             {
-                equation += "= 0";
+                builder.Insert(0, 'x').Insert(1, '=');
             }
 
             var str = builder.ToString();
@@ -100,14 +143,24 @@ namespace Pyro.Math
         }
         public static void ResolveNumbersInEq(List<SolverResult> buffer, string[] arr)
         {
-            bool CaseX(string val, bool negative)
+            bool CaseX(string val, bool negative, Operation operation)
             {
                 var altVal = val.ToLower();
-                if (altVal.Contains('x'))
+                char ch = Char.MinValue;
+                if (altVal.Any(c =>
                 {
-                    var alt = altVal.Replace('x', ' ').TrimEnd();
+                    var flag = char.IsLetter(c);
+                    if (flag)
+                    {
+                        ch = c;
+                    }
+
+                    return flag;
+                }))
+                {
+                    var alt = altVal.Replace(ch, ' ').TrimEnd();
                     
-                    var sr = new SolverResult(false, alt is not "" ? double.Parse(alt) : 1);
+                    var sr = new SolverResult(false, alt is not "" ? double.Parse(alt) : 1, operation, ch.ToString());
                     if (negative)
                     {
                         sr.Value = -sr.Value;
@@ -120,42 +173,63 @@ namespace Pyro.Math
                 return false;
             }
             bool nextIsNegative = false;
+            Operation currentOp = default;
             for (int i = 0; i < arr.Length; i++)
             {
                 var value = arr[i];
                 if (nextIsNegative)
                 {
-                    if (CaseX(value, true))
+                    if (CaseX(value, true, currentOp))
                     {
+                        currentOp = Operation.Default;
                         nextIsNegative = false;
                         continue;
                     }
 
                     buffer.Add(-double.Parse(value));
+                    currentOp = Operation.Default;
                     nextIsNegative = false;
                 }
                 else if (value == "-")
                 {
+                    currentOp = Operation.Subtraction;
                     nextIsNegative = true;
                 }
                 else if (value == "+")
                 {
-                    continue;
+                    currentOp = Operation.Addition;
+                }
+                else if (value == "*")
+                {
+                    currentOp = Operation.Multiplication;
+                }
+                else if (value == "/")
+                {
+                    currentOp = Operation.Division;
                 }
                 else
                 {
-                    if (CaseX(value, false))
+                    if (CaseX(value, false, currentOp))
                     {
                         continue;
                     }
-                    buffer.Add(double.Parse(value));
+
+                    if (value.EndsWith("!"))
+                    {
+                        value = value.Remove(value.Length - 1);
+                        buffer.Add(new SolverResult(true, ((int) double.Parse(value)).Factorial(), currentOp));
+                    }
+                    else
+                    {
+                        buffer.Add(new SolverResult(true, double.Parse(value), currentOp));
+                    }
                 }
             }
         }
         public static List<SolverResult> Solve(this List<SolverResult>[] results)
         {
             List<SolverResult> solved = new List<SolverResult>();
-            double x = 0;
+            Dictionary<string, double> dict = new Dictionary<string, double>();
             double rhs = 0;
             foreach (var result in results[0])
             {
@@ -165,7 +239,14 @@ namespace Pyro.Math
                 }
                 else
                 {
-                    x += result.Value;
+                    if (dict.ContainsKey(result.Id))
+                    {
+                        dict[result.Id] += result.Value;
+                    }
+                    else
+                    {
+                        dict.Add(result.Id, result.Value);
+                    }
                 }
             }
             
@@ -177,38 +258,140 @@ namespace Pyro.Math
                 }
                 else
                 {
-                    x -= result.Value;
+                    if (dict.ContainsKey(result.Id))
+                    {
+                        dict[result.Id] -= result.Value;
+                    }
+                    else
+                    {
+                        dict.Add(result.Id, -result.Value);
+                    }
                 }
             }
 
-            if (x != 0)
+            foreach (var kvp in dict)
             {
-                if (x < 0)
+                var x = kvp.Value;
+                if (x != 0)
                 {
-                    rhs = -rhs;
-                    x = -x;
-                }
+                    if (x != -1 && System.Math.Abs(x - 1) > 0.000001d)
+                    {
+                        rhs /= x;
+                        x = 1;
+                    }
 
-                if (x != 1)
+                    solved.Add(new SolverResult(false, x, id: kvp.Key));
+                }
+                else
                 {
-                    rhs /= x;
-                    x = 1;
+                    solved.Add(new SolverResult(true, 0));
                 }
-
-                solved.Add(new SolverResult(false, x));
-            }
-            else
-            {
-                solved.Add(new SolverResult(true, 0));
             }
 
             solved.Add(new SolverResult(true, rhs));
+            return solved;
+        }
+        
+        public static List<SolverResult> SolveFor(this List<SolverResult>[] results, List<SolverResult> missingVariables)
+        {
+            List<SolverResult> solved = new List<SolverResult>();
+            Dictionary<string, double> dict = new Dictionary<string, double>();
+            Dictionary<string, double> dictMissing = missingVariables.ToDictionary(k => k.Id, k => k.Value);
+            double rhs = 0;                                                                               
+            foreach (var result in results[0])
+            {
+                if (result.IsNumber)
+                {
+                    rhs -= result.Value;
+                }
+                else
+                {
+                    if (dict.ContainsKey(result.Id))
+                    {
+                        dict[result.Id] += result.Value;
+                    }
+                    else
+                    {
+                        dict.Add(result.Id, result.Value);
+                    }
+                }
+            }
+
+            foreach (var result in results[1])
+            {
+                if (result.IsNumber)
+                {
+                    rhs += result.Value;
+                }
+                else
+                {
+                    if (dict.ContainsKey(result.Id))
+                    {
+                        dict[result.Id] -= result.Value;
+                    }
+                    else
+                    {
+                        dict.Add(result.Id, -result.Value);
+                    }
+                }
+            }
+            
+            foreach (var kvp in dict)
+            {
+                dict[kvp.Key] = kvp.Value + dictMissing[kvp.Key];
+            }
+
+            foreach (var kvp in dict)
+            {
+                var x = kvp.Value;
+                if (x != 0)
+                {
+                    if (x < 0)
+                    {
+                        rhs = -rhs;
+                        x = -x;
+                    }
+
+                    if (System.Math.Abs(x - 1) > 0.000001d)
+                    {
+                        rhs /= x;
+                        x = 1;
+                    }
+
+                    solved.Add(new SolverResult(false, x, id: kvp.Key));
+                }
+                else
+                {
+                    solved.Add(new SolverResult(true, 0));
+                }
+            }
+
+            solved.Add(new SolverResult(true, rhs));
+            return solved;
+        }
+
+        public static List<SolverResult> MergeWith(this List<SolverResult>[] results, List<SolverResult>[] otherResults)
+        {
+            var otherSolved = otherResults.Solve();
+            var solved = results.SolveFor(otherSolved);
+
             return solved;
         }
         public static SolverResultString ToResultString(this List<SolverResult> results) => results;
         public static double ParseNumber(this string s)
         {
             return double.Parse(s);
-        } 
+        }
+
+        public static long Factorial(this int num)
+        {
+            long result = 1;
+            for (int i = 1; i < num + 1; i++)
+            {
+                result *= i;
+            }
+
+            return result;
+        }
     }
 }

--- a/Pyro.Nc/Parsing/CommandHelper.cs
+++ b/Pyro.Nc/Parsing/CommandHelper.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Pyro.IO;
+using Pyro.Math;
 using Pyro.Nc.Parsing.ArbitraryCommands;
 using Pyro.Nc.Pathing;
 using Pyro.Nc.UI;
@@ -128,7 +130,18 @@ namespace Pyro.Nc.Parsing
                     for (int i = 1; i < commandString.Length; i++)
                     {
                         var par = commandString[i];
-                        command.Parameters.Values[par[0].ToString()] = float.Parse(new string(par.Skip(1).ToArray()));
+                        var reqStr = new string(par.Skip(1).ToArray());
+                        var success = float.TryParse(reqStr, out var f);
+                        if (!success)
+                        {
+                            reqStr = reqStr.Replace("(", "").Replace(")", "");
+                            var nums = reqStr.LookForNumbers();
+                            var results = nums.Solve();
+                            f = (float) results[1].Value;
+                            Debug.Log($"Solver result: {f.ToString(CultureInfo.InvariantCulture)}");
+                        }
+
+                        command.Parameters.Values[par[0].ToString()] = f;
                     }
                     commands.Add(command);
                 }

--- a/Pyro.Nc/Parsing/MCommands/M00.cs
+++ b/Pyro.Nc/Parsing/MCommands/M00.cs
@@ -25,19 +25,9 @@ namespace Pyro.Nc.Parsing.MCommands
                 Parameters.Values.TryGetValue("P", out ms);
             }
 
-            var parameters = Parameters as MCommandParameters;
-            for (int i = 0; i < ms; i++)
-            {
-                await Task.Yield();
-                if (parameters!.Token.IsCancellationRequested)
-                {
-                    break;
-                }
-
-                await Task.Delay(1);
-                Tool.Values.IsAllowed = false;
-            }
-
+            Tool.Values.IsAllowed = false;
+            var timeSpan = TimeSpan.FromMilliseconds(ms);
+            await Task.Delay(timeSpan);
             Tool.Values.IsAllowed = true;
         }
     }

--- a/Pyro.sln
+++ b/Pyro.sln
@@ -36,6 +36,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopTester", "DesktopTes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PyroSoftwareUpdater", "PyroSoftwareUpdater\PyroSoftwareUpdater.csproj", "{A2AA4FA5-70B3-4155-A550-E6B50281F397}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PyroTester2", "PyroTester2\PyroTester2.csproj", "{0364EE5C-AB27-4A67-95C7-BD75C80DF183}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -114,5 +116,9 @@ Global
 		{A2AA4FA5-70B3-4155-A550-E6B50281F397}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A2AA4FA5-70B3-4155-A550-E6B50281F397}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A2AA4FA5-70B3-4155-A550-E6B50281F397}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0364EE5C-AB27-4A67-95C7-BD75C80DF183}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0364EE5C-AB27-4A67-95C7-BD75C80DF183}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0364EE5C-AB27-4A67-95C7-BD75C80DF183}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0364EE5C-AB27-4A67-95C7-BD75C80DF183}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
It now correctly calculates simple addition and subtraction equations.
Added factorial support.

Due to the improvements in the Pyro.Math.dll mentioned above, a new feature has been added in Pyro.Nc.Parsing, and that is being able to insert equations into the value field of a parameter for an ICommand of **_ANY_** type. An example would be doing something such as: ex. _"G00 X(11.5 - 3.2) Y(-5 + 2)"_, which would equate to writing _"G00 X8.3 Y-3"_ Another example would be doing the same but without the spaces: ex. _"G00 X11.5-3.2 Y-5+2"_, personally I prefer the clean look of the above example, but both are equally valid.